### PR TITLE
Add Nourish tags

### DIFF
--- a/src/main/resources/data/nourish/carbohydrates.json
+++ b/src/main/resources/data/nourish/carbohydrates.json
@@ -1,0 +1,30 @@
+{
+	"values": [
+		"veggie_way:fresh_tofu",
+		"veggie_way:cooked_tofu",
+		"veggie_way:fried_egg",
+		"veggie_way:cooked_carrot",
+		"veggie_way:cooked_beetroot",
+		"veggie_way:chocolate_bar",
+		"veggie_way:pumpkin_chunk",
+		"veggie_way:cactus_chunk",
+		"veggie_way:melon_chunk",
+		"veggie_way:pumpkin_soup",
+		"veggie_way:cactus_soup",
+		"veggie_way:melon_soup",
+		"veggie_way:carrot_soup",
+		"veggie_way:apple_pie",
+		"veggie_way:sweet_berry_pie",
+		"veggie_way:melon_pie",
+		"veggie_way:super_petals",
+		"veggie_way:quinoa",
+		"veggie_way:soybean",
+		"veggie_way:lentil",
+		"veggie_way:corn",
+		"veggie_way:energy_drink",
+		"veggie_way:superfood_shake",
+		"veggie_way:superfood_smoothie",
+		"veggie_way:energy_bar",
+		"veggie_way:superfood_bar"
+	]
+}

--- a/src/main/resources/data/nourish/fats.json
+++ b/src/main/resources/data/nourish/fats.json
@@ -1,0 +1,9 @@
+{
+	"values": [
+		"veggie_way:fried_egg",
+		"veggie_way:chocolate_bar",
+		"veggie_way:superfood_shake",
+		"veggie_way:superfood_smoothie",
+		"veggie_way:superfood_bar"
+	]
+}

--- a/src/main/resources/data/nourish/fruit.json
+++ b/src/main/resources/data/nourish/fruit.json
@@ -1,0 +1,13 @@
+{
+	"values": [
+		"veggie_way:melon_chunk",
+		"veggie_way:melon_soup",
+		"veggie_way:apple_pie",
+		"veggie_way:sweet_berry_pie",
+		"veggie_way:melon_pie",
+		"veggie_way:super_petals",
+		"veggie_way:superfood_shake",
+		"veggie_way:superfood_smoothie",
+		"veggie_way:superfood_bar"
+	]
+}

--- a/src/main/resources/data/nourish/protein.json
+++ b/src/main/resources/data/nourish/protein.json
@@ -1,0 +1,14 @@
+{
+	"values": [
+		"veggie_way:fresh_tofu",
+		"veggie_way:cooked_tofu",
+		"veggie_way:fried_egg",
+		"veggie_way:super_petals",
+		"veggie_way:quinoa",
+		"veggie_way:soybean",
+		"veggie_way:lentil",
+		"veggie_way:superfood_shake",
+		"veggie_way:superfood_smoothie",
+		"veggie_way:superfood_bar"
+	]
+}

--- a/src/main/resources/data/nourish/sweets.json
+++ b/src/main/resources/data/nourish/sweets.json
@@ -1,0 +1,14 @@
+{
+	"values": [
+		"veggie_way:chocolate_bar",
+		"veggie_way:apple_pie",
+		"veggie_way:sweet_berry_pie",
+		"veggie_way:melon_pie",
+		"veggie_way:super_petals",
+		"veggie_way:energy_drink",
+		"veggie_way:superfood_shake",
+		"veggie_way:superfood_smoothie",
+		"veggie_way:energy_bar",
+		"veggie_way:superfood_bar"
+	]
+}

--- a/src/main/resources/data/nourish/vegetables.json
+++ b/src/main/resources/data/nourish/vegetables.json
@@ -1,0 +1,21 @@
+{
+	"values": [
+		"veggie_way:fresh_tofu",
+		"veggie_way:cooked_tofu",
+		"veggie_way:cooked_carrot",
+		"veggie_way:cooked_beetroot",
+		"veggie_way:pumpkin_chunk",
+		"veggie_way:cactus_chunk",
+		"veggie_way:pumpkin_soup",
+		"veggie_way:cactus_soup",
+		"veggie_way:carrot_soup",
+		"veggie_way:super_petals",
+		"veggie_way:quinoa",
+		"veggie_way:soybean",
+		"veggie_way:lentil",
+		"veggie_way:corn",
+		"veggie_way:superfood_shake",
+		"veggie_way:superfood_smoothie",
+		"veggie_way:superfood_bar"
+	]
+}


### PR DESCRIPTION
Why create a mod that adds vegetarian protein options if protein doesn't even matter? That's why I've created these tags to add support for the [Nourish](https://www.curseforge.com/minecraft/mc-mods/nourish) mod. These tags should work the same for 1.16.4 now, and 1.16.5 once Nourish updates to it.